### PR TITLE
Never shuffle 1 and last

### DIFF
--- a/LISEZMOI.md
+++ b/LISEZMOI.md
@@ -43,7 +43,7 @@ Le script renvoie le nouvel ordonnancement de vos paragraphes sous forme d'une l
 
 - Si vous souhaitez mélanger vos paragraphes mais garder certains à leur place d'origine (dans l'exemple, les 1, 156, 287, 342 et 400 ne bougeront pas):
 ```
-python odt.hyperAVH.py mon_AVH.odt --shuffle --keep 1 156 287 342 400
+python odt.hyperAVH.py mon_AVH.odt --shuffle --keep 156 287 342
 ```
 
 # diagAVH

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The script returns the new range of your paragraphs as a table of numbers. By de
 
 - If you want to shuffle your paragraphs but keep some of them in their original place (in the example, 1, 156, 287, 342 and 400 will be kept):
 ```
-python odt.hyperAVH.py --EN my_gamebook.odt --shuffle --keep 1 156 287 342 400
+python odt.hyperAVH.py --EN my_gamebook.odt --shuffle --keep 156 287 342
 ```
 
 # diagAVH

--- a/odt.hyperAVH.py
+++ b/odt.hyperAVH.py
@@ -106,7 +106,7 @@ if args.shuffle:
     new_paragraphs = list(range(1,length+1))
     random.shuffle(new_paragraphs)
     # put back kept paragraphs to their own place
-    kept = args.keep or [1,length]
+    kept = (args.keep or []) + [1, length]
     for k in kept:
         # logging.debug("k="+str(k))
         a = new_paragraphs[k-1] # value at index k


### PR DESCRIPTION
I can't think of a single use case where anyone would want to mix these two.
Good old Advelh never did and nobody ever complained about that.
Heck, even the examples in the README kept them in place.
However, I can think of a few authors (well, at least me) who will be puzzled after typing `--keep 42` to see the 1 having ended up in the middle of the document. It just doesn't feel natural that it can do that.

Also, weird stuff appears to happen if the last section is moved (in one of my attempts it was simply cut off); removing the option seems like the simplest way to fix that issue.