### PR TITLE
Add messages in case something goes wrong

### DIFF
--- a/odt.hyperAVH.py
+++ b/odt.hyperAVH.py
@@ -92,6 +92,8 @@ if links:
         print(h.getparent().text + h.text)
     quit()
 
+bugged_sections = []
+
 # create bookmarks into 'heading' nodes, then 'paragraph' nodes
 paragraph = 1
 search = t + 'h'
@@ -99,26 +101,6 @@ paragraph = bookmarks(search, paragraph)
 search = t + 'p'
 paragraph = bookmarks(search, paragraph)
 print(paragraph - 1)
-
-# shuffle : create randomized paragraphs array
-if args.shuffle:
-    length = sum(1 for _ in tree.iter(t+'bookmark'))
-    new_paragraphs = list(range(1,length+1))
-    random.shuffle(new_paragraphs)
-    # put back kept paragraphs to their own place
-    kept = (args.keep or []) + [1, length]
-    for k in kept:
-        # logging.debug("k="+str(k))
-        a = new_paragraphs[k-1] # value at index k
-        # logging.debug("a="+str(a))
-        b = new_paragraphs.index(k) # index where k is the value
-        # logging.debug("b="+str(b))
-        new_paragraphs[k-1] = k
-        new_paragraphs[b] = a
-    new_paragraphs.insert(0,0)
-    
-    # display new paragraphs order
-    print(new_paragraphs)
 
 # create turn to's
 for p in tree.iter(t+'p'): # noeud "paragraph"
@@ -188,11 +170,33 @@ for p in tree.iter(t+'p'): # noeud "paragraph"
                     number,
                     ''.join(p.itertext())
                 )
+                if args.shuffle:
+                    logging.warning('Section %s will be excluded from the shuffle to avoid further incidents.', number)
+                    bugged_sections.append(int(number))
         
         logging.debug("p = " + show(p))
 
 # shuffle ------------------------------------------
 if args.shuffle:
+    # shuffle : create randomized paragraphs array
+    length = sum(1 for _ in tree.iter(t+'bookmark'))
+    new_paragraphs = list(range(1,length+1))
+    random.shuffle(new_paragraphs)
+    # put back kept paragraphs to their own place
+    kept = (args.keep or []) + [1, length] + bugged_sections
+    for k in kept:
+        # logging.debug("k="+str(k))
+        a = new_paragraphs[k-1] # value at index k
+        # logging.debug("a="+str(a))
+        b = new_paragraphs.index(k) # index where k is the value
+        # logging.debug("b="+str(b))
+        new_paragraphs[k-1] = k
+        new_paragraphs[b] = a
+    new_paragraphs.insert(0,0)
+
+    # display new paragraphs order
+    print(new_paragraphs)
+
     paragraph=0
     blocks = []
     block = []

--- a/odt.hyperAVH.py
+++ b/odt.hyperAVH.py
@@ -165,13 +165,10 @@ for p in tree.iter(t+'p'): # noeud "paragraph"
                     p.insert(0,link)
                     p.text = before
             if not number_found:
-                logging.error(
-                    'Could not generate hyperlinkg pointing to section %s in sentence "%s". Please add it by hand.',
-                    number,
-                    ''.join(p.itertext())
-                )
+                sentence = ''.join(p.itertext())
+                logging.error(f'Could not generate hyperlinkg pointing to section {number} in sentence "{sentence}". Please add it by hand.')
                 if args.shuffle:
-                    logging.warning('Section %s will be excluded from the shuffle to avoid further incidents.', number)
+                    logging.warning(f'Section {number} will be excluded from the shuffle to avoid further incidents.')
                     bugged_sections.append(int(number))
         
         logging.debug("p = " + show(p))

--- a/odt.hyperAVH.py
+++ b/odt.hyperAVH.py
@@ -134,6 +134,7 @@ for p in tree.iter(t+'p'): # noeud "paragraph"
     if numbers:
         # reverse processing
         for number in reversed(numbers):
+            number_found = False
             logging.debug("RENVOI = "+number)
             # process child nodes if needed
             for c in p.findall('.//'):
@@ -142,6 +143,7 @@ for p in tree.iter(t+'p'): # noeud "paragraph"
                 if c.tail:
                     logging.debug("cTAIL = "+c.tail)
                     if number in c.tail:
+                        number_found = True
                         logging.debug("cTAIL! = "+c.tail)
                         i = c.getparent().index(c)
                         m = re.match("(.*\D*)" + number + "(\D*)",c.tail)
@@ -153,6 +155,7 @@ for p in tree.iter(t+'p'): # noeud "paragraph"
                 if c.text:
                     logging.debug("cTEXT = "+c.text)
                     if number in c.text:
+                        number_found = True
                         logging.debug("cTEXT! = "+c.text)
                         m = re.match("(.*\D*)" + number + "(\D*)",c.text)
                         try: # an AttributeError may happen if number is substring of another (longer) number
@@ -171,6 +174,7 @@ for p in tree.iter(t+'p'): # noeud "paragraph"
             if p.text:
                 logging.debug("pTEXT = "+p.text)
                 if number in p.text:
+                    number_found = True
                     logging.debug("pTEXT! = "+p.text)
                     m = re.match("(.*\D*)" + number + "(\D*)",p.text)
                     before = m.group(1)
@@ -178,6 +182,12 @@ for p in tree.iter(t+'p'): # noeud "paragraph"
                     link = hyperlink(number,after)
                     p.insert(0,link)
                     p.text = before
+            if not number_found:
+                logging.error(
+                    'Could not generate hyperlinkg pointing to section %s in sentence "%s". Please add it by hand.',
+                    number,
+                    ''.join(p.itertext())
+                )
         
         logging.debug("p = " + show(p))
 


### PR DESCRIPTION
J'avais un bug de l'enfer avec une section pas gérée parce que son numéro s'est retrouvé je ne sais comment coupé en deux par un tag:
```
rendez-vous au 4<text:span text:style-name="T735">0</text:span>
```
Le problème ayant l'air à la fois rare et pénible à corriger, j'ai pas creusé. En revanche, je me suis dit que c'était l'occasion de rajouter quelques messages d'erreur pour quand un imprévu de ce genre se produit.

Au passage, pour éviter des histoires de numéros plus raccords (numéro du lien pas mis à jour vu que pas de lien), je vire aussi la section en question du shuffle.