### PR TITLE
Out of range exception "fix"

### DIFF
--- a/odt.hyperAVH.py
+++ b/odt.hyperAVH.py
@@ -322,6 +322,8 @@ if __name__ == '__main__':
         while paragraph < length:
             foundnextbkm = False
             for e in tree.iter():
+                if paragraph >= length:
+                    break
                 if e.tag == t +'p' or e.tag == t +'h':
                     for ee in e.iter():
                         if ee.tag == t + 'bookmark':


### PR DESCRIPTION
En tentant de mélanger un participant au mini-Yaz',  je me suis mangé :
```
Traceback (most recent call last):
  File "odt.hyperAVH.py", line 334, in <module>
    for new_e in new_blocks[paragraph]:
IndexError: list index out of range
```

En rajoutant ce `if`, le problème disparaît sans effet de bord apparent. Après, j'ai pas creusé, c'est peut-être le symptôme d'un autre problème, qu'il serait plus efficace de traiter à sa source plutôt que juste avant qu'il n'explose.